### PR TITLE
Remove ModuleAdminControllers from SEO & URLs page

### DIFF
--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: '.gmdate('D, d M Y H:i:s').' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/upgrade/upgrade-2.0.1.php
+++ b/upgrade/upgrade-2.0.1.php
@@ -1,26 +1,20 @@
 <?php
 /**
- * 2007-2016 PrestaShop
+ * 2007-2020 PrestaShop and Contributors
  *
  * NOTICE OF LICENSE
  *
- * This source file is subject to the Academic Free License (AFL 3.0)
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
  * that is bundled with this package in the file LICENSE.txt.
  * It is also available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
+ * https://opensource.org/licenses/AFL-3.0
  * If you did not receive a copy of the license and are unable to
  * obtain it through the world-wide-web, please send an email
  * to license@prestashop.com so we can send you a copy immediately.
  *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to http://www.prestashop.com for more information.
- *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2016 PrestaShop SA
- * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
 

--- a/upgrade/upgrade-2.0.1.php
+++ b/upgrade/upgrade-2.0.1.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * 2007-2016 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param Ps_faviconnotificationbo $module
+ *
+ * @return bool
+ */
+function upgrade_module_2_0_1($module)
+{
+    $result = true;
+
+    // Remove our ModuleAdminControllers from SEO & URLs page
+    foreach ($module->adminControllers as $controller) {
+        $metaId = Db::getInstance()->getValue('
+            SELECT id_meta
+            FROM `' . _DB_PREFIX_ . 'meta`
+            WHERE page="' . pSQL('module-' . $module->name . '-' . $controller) . '"'
+        );
+
+        if ($metaId) {
+            $result = $result && Db::getInstance()->delete(
+                    'meta_lang',
+                    'id_meta = ' . (int) $metaId
+                );
+            $result = $result && Db::getInstance()->delete(
+                    'meta',
+                    'id_meta = ' . (int) $metaId
+                );
+        }
+    }
+
+    return $result;
+}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `Module::$controllers` is an undocumented reserved var used to register `ModuleFrontController` in SEO & URLs page on BO in order to allow merchant to customize rewrite link and page title, meta keyword, meta description... It should never be used for a `ModuleAdminController`
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below

## How to test ?

Install current module, go to BO > Preferences > SEO & URLs, search `ps_faviconnotificationbo`. and see it in the list: this list item is bad.
With new module
- if you upgrade, the bad list item is gone
- if you install, it will not add the bad list item

![ps_faviconnotificationbo-admincontrollers](https://user-images.githubusercontent.com/5262628/78541178-7c0ad900-77f5-11ea-968a-4178069f8682.png)
![ps_faviconnotificationbo-admincontroller](https://user-images.githubusercontent.com/5262628/78541188-7f05c980-77f5-11ea-88ea-beefe97000be.png)
