### PR TITLE
Fixed BackOffice Notification when Settings disable it

### DIFF
--- a/controllers/admin/AdminAjaxFaviconBOController.php
+++ b/controllers/admin/AdminAjaxFaviconBOController.php
@@ -14,11 +14,19 @@
 * International Registered Trademark & Property of PrestaShop SA
 */
 
+use PrestaShop\PrestaShop\Core\Domain\Notification\Query\GetNotificationLastElements;
+use PrestaShop\PrestaShop\Core\Domain\Notification\QueryResult\NotificationsResults;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
+
 class AdminAjaxFaviconBOController extends ModuleAdminController
 {
     public function ajaxProcessGetNotifications()
     {
-        $notification = new Notification;
-        $this->ajaxDie(json_encode($notification->getLastElements()));
+        /** @var NotificationsResults $elements */
+        $elements = SymfonyContainer::getInstance()->get('prestashop.core.query_bus')->handle(
+            new GetNotificationLastElements(Context::getContext()->employee->id)
+        );
+        header('Content-Type: application/json');
+        $this->ajaxRender(json_encode($elements->getNotificationsResultsForJS()));
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>
:warning: Test IT After PrestaShop/PrestaShop#19037
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixed Favicon Notification number when Settings disable it
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#18938
| How to test?  |  1. Menu - Configure -> Advanced Parameters -> Administration<br>2. Define Notifications On for new Messages, but Off for new Customers and Orders.<br>3. On FO, make a new order<br>4. **BEFORE** The number increase<br>4. **AFTER** The number take settings for displaying notifications

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
